### PR TITLE
⚡ Enable safe async requests in UrlHiveClient

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -40,7 +40,10 @@
         }
     },
     "config": {
-        "sort-packages": true
+        "sort-packages": true,
+        "allow-plugins": {
+            "pestphp/pest-plugin": true
+        }
     },
     "minimum-stability": "dev",
     "prefer-stable": true

--- a/src/UrlHiveClient.php
+++ b/src/UrlHiveClient.php
@@ -37,7 +37,7 @@ class UrlHiveClient
 
     public function getHttpClient(): PendingRequest
     {
-        return $this->http();
+        return clone $this->http();
     }
 
     public function url(): UrlResource

--- a/tests/AsyncTest.php
+++ b/tests/AsyncTest.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Support\Facades\Http;
+use UrlHive\Laravel\UrlHiveClient;
+use GuzzleHttp\Promise\PromiseInterface;
+
+it('can mix async and sync requests safely', function () {
+    Http::fake([
+        '*' => Http::response(['data' => ['short_url' => 'https://urlhive.com/test']], 200),
+    ]);
+
+    $client = new UrlHiveClient([
+        'base_url' => 'https://api.test',
+        'api_token' => 'token'
+    ]);
+
+    // 1. Start an async request
+    // This should NOT affect the client's internal state for subsequent requests
+    $promise = $client->getHttpClient()->async()->get('/async');
+
+    expect($promise)->toBeInstanceOf(PromiseInterface::class);
+
+    // 2. Make a synchronous call using a Resource
+    // This should succeed and not crash
+    $response = $client->url()->shorten('https://example.com');
+
+    expect($response)->toBeArray();
+    expect($response['data']['short_url'])->toBe('https://urlhive.com/test');
+
+    // 3. Ensure the promise can still be settled
+    $promise->wait();
+});


### PR DESCRIPTION
- Modified `src/UrlHiveClient.php` to return `clone $this->http()` in `getHttpClient()`.
- Added `tests/AsyncTest.php` to test concurrent/mixed usage of async and sync requests.
- Verified that existing tests pass.

---
*PR created automatically by Jules for task [13592100711179867224](https://jules.google.com/task/13592100711179867224) started by @klc*